### PR TITLE
feat(commp): add optional snapshot layer capture during streaming CommP

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,26 @@ in order to convert it to a proper [cid.Cid](https://pkg.go.dev/github.com/ipfs/
 
 The output of this library is 100% identical to [ffi.GeneratePieceCIDFromFile()](https://github.com/filecoin-project/filecoin-ffi/blob/d82899449741ce19/proofs.go#L177-L196)
 
+## Snapshot Layer Capture
+
+`NewCalcWithSnapshot(layerIdx)` creates a calculator that captures an intermediate Merkle tree layer during streaming CommP computation.
+This is useful for PDP proof caching: the captured layer allows proofs to be generated from small data sections rather than rebuilding the full tree.
+
+```go
+cp := commp.NewCalcWithSnapshot(commp.SnapshotLayerIndex(4 << 20)) // ~4 MiB sections
+defer cp.Reset()
+
+io.Copy(cp, reader)
+
+commP, paddedSize, snapshot, err := cp.DigestWithSnapshot()
+// snapshot.Nodes contains the captured layer hashes
+// snapshot is nil if the data was too small for the requested layer
+```
+
+See the [GoDoc](https://pkg.go.dev/github.com/filecoin-project/go-fil-commp-hashhash) for details.
 
 ## Lead Maintainer
 [Peter 'ribasushi' Rabbitson](https://github.com/ribasushi)
-
 
 ## License
 [SPDX-License-Identifier: Apache-2.0 OR MIT](LICENSE.md)

--- a/commp.go
+++ b/commp.go
@@ -37,21 +37,34 @@ import (
 //	}
 type Calc struct {
 	state
-	mu sync.Mutex
+	mu       sync.Mutex
+	snapshot *snapshotState // nil when not capturing a snapshot layer
 }
+
+// snapshotState holds the configuration and collected nodes for snapshot layer
+// capture. It is only allocated when NewCalcWithSnapshot is used. Only a single
+// goroutine (the one at layerIdx-1) writes to nodes, so no synchronization is
+// needed.
+type snapshotState struct {
+	layerIdx int        // which tree layer to capture
+	nodes    [][32]byte // collected nodes, appended by single writer goroutine
+}
+
 type state struct {
 	quadsEnqueued uint64
-	layerQueues   [MaxLayers + 2]chan []byte // one extra layer for the initial leaves, one more for the dummy never-to-use channel
+	layerQueues   [MaxLayers + 2]chan []byte // fixed array, concurrency-safe
 	resultCommP   chan []byte
 	buffer        []byte
 }
 
 var _ hash.Hash = &Calc{} // make sure we are hash.Hash compliant
 
-// MaxLayers is the current maximum height of the rust-fil-proofs proving tree.
-const MaxLayers = uint(31) // result of log2( 64 GiB / 32 )
+// MaxLayers is the maximum height of the merkle tree. This supports pieces up
+// to ~32 PiB padded (2^55 bytes). The cost is a fixed stackedNulPadding array
+// of 50 * 32 = 1600 bytes computed once at init.
+const MaxLayers = uint(50)
 
-// MaxPieceSize is the current maximum size of the rust-fil-proofs proving tree.
+// MaxPieceSize is the maximum padded piece size supported by this library.
 const MaxPieceSize = uint64(1 << (MaxLayers + 5))
 
 // MaxPiecePayload is the maximum amount of data that one can Write() to the
@@ -109,7 +122,10 @@ func (cp *Calc) Reset() {
 		close(cp.layerQueues[0])
 		<-cp.resultCommP
 	}
-	cp.state = state{} // reset
+	if cp.snapshot != nil {
+		cp.snapshot.nodes = cp.snapshot.nodes[:0]
+	}
+	cp.state = state{}
 	cp.mu.Unlock()
 }
 
@@ -133,21 +149,27 @@ func (cp *Calc) Sum(buf []byte) []byte {
 // Reset() to clean up background goroutines before abandoning the Calc object.
 func (cp *Calc) Digest() (commP []byte, paddedPieceSize uint64, err error) {
 	cp.mu.Lock()
+	defer cp.mu.Unlock()
 
-	defer func() {
-		// reset only if we did succeed
-		if err == nil {
-			cp.state = state{}
+	commP, paddedPieceSize, err = cp.digestCore()
+	if err == nil {
+		if cp.snapshot != nil {
+			cp.snapshot.nodes = cp.snapshot.nodes[:0]
 		}
-		cp.mu.Unlock()
-	}()
+		cp.state = state{}
+	}
+	return
+}
 
+// digestCore performs the digest computation without resetting state.
+// Caller must hold cp.mu. After this returns successfully, all layer
+// goroutines have completed and all snapshot nodes have been collected.
+func (cp *Calc) digestCore() (commP []byte, paddedPieceSize uint64, err error) {
 	if processed := cp.quadsEnqueued*uint64(quadPayload) + uint64(len(cp.buffer)); processed < MinPiecePayload {
-		err = xerrors.Errorf(
+		return nil, 0, xerrors.Errorf(
 			"insufficient state accumulated: commP is not defined for inputs shorter than %d bytes, but only %d processed so far",
 			MinPiecePayload, processed,
 		)
-		return
 	}
 
 	// If any, flush remaining bytes padded up with zeroes
@@ -299,6 +321,9 @@ func (cp *Calc) addLayer(myIdx uint) {
 	}
 	cp.layerQueues[myIdx+1] = make(chan []byte, layerQueueDepth)
 
+	// capture snapshot nodes when hashing produces the target layer
+	collectSnapshot := cp.snapshot != nil && int(myIdx) == cp.snapshot.layerIdx-1
+
 	go func() {
 		s256 := sha256simd.New()
 		var twinHold []byte
@@ -325,7 +350,7 @@ func (cp *Calc) addLayer(myIdx uint) {
 
 				if twinHold != nil {
 					copy(twinHold[32:64], stackedNulPadding[myIdx])
-					cp.hashSlab254(s256, 0, twinHold[0:64])
+					cp.hashSlab254(s256, 0, collectSnapshot, twinHold[0:64])
 					cp.layerQueues[myIdx+1] <- twinHold[0:64:64]
 				}
 
@@ -336,11 +361,11 @@ func (cp *Calc) addLayer(myIdx uint) {
 
 			switch {
 			case uint64(len(slab)) > uint64(1<<(5+myIdx)): // uint64 cast needed on 32-bit systems
-				cp.hashSlab254(s256, myIdx, slab)
+				cp.hashSlab254(s256, myIdx, collectSnapshot, slab)
 				cp.layerQueues[myIdx+1] <- slab
 			case twinHold != nil:
 				copy(twinHold[32:64], slab[0:32])
-				cp.hashSlab254(s256, 0, twinHold[0:64])
+				cp.hashSlab254(s256, 0, collectSnapshot, twinHold[0:64])
 				cp.layerQueues[myIdx+1] <- twinHold[0:32:64]
 				twinHold = nil
 			default:
@@ -360,14 +385,133 @@ func (cp *Calc) addLayer(myIdx uint) {
 	}()
 }
 
-func (cp *Calc) hashSlab254(h hash.Hash, layerIdx uint, slab []byte) {
+func (cp *Calc) hashSlab254(h hash.Hash, layerIdx uint, collectSnapshot bool, slab []byte) {
 	stride := 1 << (5 + layerIdx)
 	for i := 0; len(slab) > i+stride; i += 2 * stride {
 		h.Reset()
 		h.Write(slab[i : i+32])
 		h.Write(slab[i+stride : 32+i+stride])
 		h.Sum(slab[i:i])[31] &= 0x3F // callers expect we will reuse-reduce-recycle
+
+		if collectSnapshot {
+			var node [32]byte
+			copy(node[:], slab[i:i+32])
+			cp.snapshot.nodes = append(cp.snapshot.nodes, node)
+		}
 	}
+}
+
+// SnapshotLayer holds a captured intermediate merkle tree layer from a streaming
+// CommP computation. Each node is the root hash of a subtree covering a
+// contiguous section of the piece data.
+type SnapshotLayer struct {
+	// LayerIndex is the tree layer that was captured (0 = leaf level).
+	LayerIndex int
+	// Nodes contains the 32-byte hashes in sequential order, zero-padded to
+	// the expected count for pieces that don't fill their padded size.
+	Nodes [][32]byte
+}
+
+// SnapshotLayerIndex computes the tree layer index for a target padded section
+// size. Each node at the returned layer covers approximately
+// targetPaddedBytesPerNode bytes of FR32-padded data. The minimum return value
+// is 1 (pairs of leaves, 64 padded bytes per node).
+func SnapshotLayerIndex(targetPaddedBytesPerNode uint64) int {
+	if targetPaddedBytesPerNode <= 64 {
+		return 1
+	}
+	return bits.Len64(targetPaddedBytesPerNode/32 - 1)
+}
+
+// NewCalcWithSnapshot creates a CommP calculator that captures the merkle tree
+// layer at the given index during streaming computation. The minimum layer
+// index is 1 (pairs of leaves); higher indices capture coarser nodes. Values
+// below 1 are clamped.
+//
+// Each node at layer L covers 2^L leaves, and each leaf is 32 padded bytes,
+// so a node's padded coverage is 32 << L bytes. Use [SnapshotLayerIndex] to
+// compute the layer for a target section size. For example, layer 17 gives
+// ~4 MiB sections, layer 6 gives ~2 KiB sections.
+//
+// The layer index is validated against the final tree height during
+// DigestWithSnapshot. If the requested layer exceeds the tree height for the
+// data actually written, DigestWithSnapshot returns a nil snapshot.
+func NewCalcWithSnapshot(layerIdx int) *Calc {
+	if layerIdx < 1 {
+		layerIdx = 1
+	}
+	return &Calc{
+		snapshot: &snapshotState{
+			layerIdx: layerIdx,
+		},
+	}
+}
+
+// DigestWithSnapshot returns the CommP digest and the captured snapshot layer.
+// The Calc must have been created with NewCalcWithSnapshot; returns an error
+// otherwise.
+//
+// If the requested layer index exceeds the tree height for the data written,
+// the CommP and padded size are still returned but snapshot will be nil
+// (err == nil). This allows callers to always obtain a valid CommP regardless
+// of whether the data was large enough for the requested snapshot granularity.
+//
+// Calling plain Digest() on a snapshot-enabled Calc discards collected snapshot
+// nodes and returns only the CommP.
+//
+// On success, the internal state is reset. On error, callers must call Reset()
+// before abandoning the Calc.
+func (cp *Calc) DigestWithSnapshot() (commP []byte, paddedPieceSize uint64, snapshot *SnapshotLayer, err error) {
+	if cp.snapshot == nil {
+		return nil, 0, nil, xerrors.New("DigestWithSnapshot called on Calc without snapshot configuration; use NewCalcWithSnapshot")
+	}
+
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	// digestCore flushes the buffer and drains the layer pipeline. When it
+	// returns, all goroutines have completed and all snapshot nodes have been
+	// collected.
+	commP, paddedPieceSize, err = cp.digestCore()
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	layerIdx := cp.snapshot.layerIdx
+
+	// If the requested layer exceeds the tree height, return the CommP but
+	// no snapshot. The caller can check for nil to detect this case.
+	numLeaves := paddedPieceSize / 32
+	treeHeight := bits.Len64(numLeaves - 1)
+	if layerIdx > treeHeight {
+		cp.state = state{}
+		cp.snapshot.nodes = cp.snapshot.nodes[:0]
+		return commP, paddedPieceSize, nil, nil
+	}
+
+	// Compute expected node count from the actual padded size and zero-pad
+	// any trailing nodes for pieces that don't fill their padded size
+	expectedNodes := int(numLeaves >> uint(layerIdx))
+
+	out := make([][32]byte, expectedNodes)
+	copy(out, cp.snapshot.nodes)
+
+	if len(cp.snapshot.nodes) < expectedNodes {
+		var pad [32]byte
+		copy(pad[:], stackedNulPadding[layerIdx])
+		for i := len(cp.snapshot.nodes); i < expectedNodes; i++ {
+			out[i] = pad
+		}
+	}
+
+	// Reset state
+	cp.state = state{}
+	cp.snapshot.nodes = cp.snapshot.nodes[:0]
+
+	return commP, paddedPieceSize, &SnapshotLayer{
+		LayerIndex: layerIdx,
+		Nodes:      out,
+	}, nil
 }
 
 // PadCommP is experimental, do not use it.

--- a/commp_test.go
+++ b/commp_test.go
@@ -60,7 +60,7 @@ func TestCommP(t *testing.T) {
 			pr, pw := io.Pipe()
 			var randErr error
 			go func() {
-				defer pw.Close()
+				defer pw.Close() //nolint:errcheck
 
 				// This go-routine logic is the same as in
 				// jbenet/go-random. It's copied here to allow doing
@@ -223,7 +223,7 @@ func getTestCases(path string, shortOnly bool) ([]testCase, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	lineScanner := bufio.NewScanner(f)
 	for lineScanner.Scan() {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/filecoin-project/go-fil-commp-hashhash
 go 1.25
 
 require (
-	github.com/minio/sha256-simd v1.0.1-0.20230130105256-d9c3aea9e949
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
+	github.com/minio/sha256-simd v1.0.1
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,9 @@
-github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/minio/sha256-simd v1.0.1-0.20230130105256-d9c3aea9e949 h1:/wWTRC45sBSB8czmeKwl14WL8Pd3Z+Bd3FXPPrDyPuw=
-github.com/minio/sha256-simd v1.0.1-0.20230130105256-d9c3aea9e949/go.mod h1:svsp3c9I8SlWYKpIFAZMgdvmFn8DIN5C9ktYpzZEj80=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,12 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/minio/sha256-simd v1.0.1-0.20230130105256-d9c3aea9e949 h1:/wWTRC45sBSB8czmeKwl14WL8Pd3Z+Bd3FXPPrDyPuw=
 github.com/minio/sha256-simd v1.0.1-0.20230130105256-d9c3aea9e949/go.mod h1:svsp3c9I8SlWYKpIFAZMgdvmFn8DIN5C9ktYpzZEj80=
+github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
+github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=
+golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,546 @@
+package commp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"testing"
+
+	randmath "math/rand"
+)
+
+const (
+	snapshotBenchSize = 31 << 20 // same as BenchmarkCommP for comparison
+
+	// testLayerIdx captures at ~2 KiB granularity per node (layer 6 = 2^6 = 64 leaves * 32 bytes)
+	testLayerIdx = 6
+	// prodLayerIdx captures at ~4 MiB granularity per node (layer 17 = 2^17 = 131072 leaves * 32 bytes)
+	prodLayerIdx = 17
+)
+
+func BenchmarkDigest(b *testing.B) {
+	src := bytes.NewReader(make([]byte, snapshotBenchSize))
+	cp := &Calc{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetBytes(snapshotBenchSize)
+	for i := 0; i < b.N; i++ {
+		if _, err := src.Seek(0, 0); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(cp, src); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := cp.Digest(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDigestWithSnapshot(b *testing.B) {
+	src := bytes.NewReader(make([]byte, snapshotBenchSize))
+	cp := NewCalcWithSnapshot(prodLayerIdx)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetBytes(snapshotBenchSize)
+	for i := 0; i < b.N; i++ {
+		if _, err := src.Seek(0, 0); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(cp, src); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, _, err := cp.DigestWithSnapshot(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDigestWithSnapshotFineGrained(b *testing.B) {
+	src := bytes.NewReader(make([]byte, snapshotBenchSize))
+	cp := NewCalcWithSnapshot(testLayerIdx)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetBytes(snapshotBenchSize)
+	for i := 0; i < b.N; i++ {
+		if _, err := src.Seek(0, 0); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(cp, src); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, _, err := cp.DigestWithSnapshot(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// snapshotFixture holds a test case for snapshot verification. PayloadSize and
+// PieceSize come from testdata/random.txt; RawCommP is decoded at test time.
+type snapshotFixture struct {
+	PayloadSize int64
+	PieceSize   uint64
+	CommPCID    string // base32 multibase CID from test vectors
+}
+
+// Test fixtures selected to exercise snapshot layer capture across a range of
+// tree shapes and fill levels. All have known-good CommP values from
+// testdata/random.txt, validated against filecoin-ffi.
+var snapshotFixtures = []snapshotFixture{
+	// Small sizes: few snapshot nodes at testLayerIdx
+	{8128, 8192, "baga6ea4seaqotwrimtqoatryhi3zmcjvykr3uyybsx6n5fmdq2wgo6zw7nz3kiq"},
+	{65024, 65536, "baga6ea4seaqgjaavyognzadlkkcwaovy4ij7grb3eso65dqvwkiqfg5g3cb3qbi"},
+	// Partial fill: exercises null-padded snapshot nodes
+	{786432, 1048576, "baga6ea4seaqdqltvzfcyx5nu3o6yazc6ftuxt6xkhwjywatjmjrbj6shwsqlcaq"},
+	// Exact fill at production snapshot boundary
+	{1040384, 1048576, "baga6ea4seaqio7pi5twddpb4qevcestrwtc77nuou7o2xilhkhkj46irbsolaoq"},
+	// Production snapshot boundary (~4 MiB)
+	{4161536, 4194304, "baga6ea4seaqoarx7s4i2azmftkspmosawixgqg3frdo3iugalasu5burrgu3qbq"},
+	// MinSizeForCache threshold (32 MiB)
+	{33292288, 33554432, "baga6ea4seaqgseawqou6toeg5spmgnjsamjiqq2bhbamfjtj5e67ytnncwuasiq"},
+	// Medium-large
+	{133169152, 134217728, "baga6ea4seaqk3bkri6x5kqcxezyq63v7ct37rhlsb7pgynmtifmwqivbhvq4why"},
+	// Largest practical for unit tests (~1 GiB memtree for cross-check)
+	{532676608, 536870912, "baga6ea4seaqexfdfvlgmue3jn6wmpyfgqq3itkdyae2vz3bw6tzcsrddlx7x6my"},
+}
+
+// generateDeterministicData produces seed-1337 random data matching
+// jbenet/go-random, identical to testdata/random.txt generation.
+func generateDeterministicData(size int64) []byte {
+	rng := randmath.New(randmath.NewSource(1337))
+	buf := make([]byte, size)
+	for i := int64(0); i < size; {
+		n := rng.Uint32()
+		for j := 0; j < 4 && i < size; j++ {
+			buf[i] = byte(n & 0xff)
+			n >>= 8
+			i++
+		}
+	}
+	return buf
+}
+
+func decodeFixtureCommP(cidStr string) [32]byte {
+	rawCid, err := b32dec.DecodeString(cidStr[1:]) // [1:] drops the multibase 'b'
+	if err != nil {
+		panic(fmt.Sprintf("failed to decode CID %q: %v", cidStr, err))
+	}
+	var commP [32]byte
+	copy(commP[:], rawCid[len(rawCid)-32:])
+	return commP
+}
+
+// TestSnapshotCommPMatchesFixtures verifies that DigestWithSnapshot produces
+// the same CommP as the standard Digest path, anchored against external test
+// vectors from testdata/random.txt.
+func TestSnapshotCommPMatchesFixtures(t *testing.T) {
+	t.Parallel()
+
+	for _, fx := range snapshotFixtures {
+		fx := fx
+		t.Run(fmt.Sprintf("%d", fx.PayloadSize), func(t *testing.T) {
+			t.Parallel()
+
+			if testing.Short() && fx.PayloadSize > 1<<26 {
+				t.Skip("skipping large fixture in short mode")
+			}
+
+			expectedCommP := decodeFixtureCommP(fx.CommPCID)
+			data := generateDeterministicData(fx.PayloadSize)
+
+			cp := NewCalcWithSnapshot(testLayerIdx)
+			defer cp.Reset()
+
+			if _, err := io.Copy(cp, bytes.NewReader(data)); err != nil {
+				t.Fatalf("Copy failed: %v", err)
+			}
+
+			commP, paddedSize, snapshot, err := cp.DigestWithSnapshot()
+			if err != nil {
+				t.Fatalf("DigestWithSnapshot failed: %v", err)
+			}
+
+			if paddedSize != fx.PieceSize {
+				t.Errorf("padded size: got %d, want %d", paddedSize, fx.PieceSize)
+			}
+
+			var gotCommP [32]byte
+			copy(gotCommP[:], commP)
+			if gotCommP != expectedCommP {
+				t.Errorf("CommP mismatch:\n  got  %x\n  want %x", gotCommP, expectedCommP)
+			}
+
+			if snapshot == nil {
+				t.Fatal("snapshot is nil")
+			}
+
+			expectedLeaves := fx.PieceSize / 32
+			expectedNodes := int(expectedLeaves >> uint(snapshot.LayerIndex))
+			if len(snapshot.Nodes) != expectedNodes {
+				t.Errorf("snapshot node count: got %d, want %d (layer %d, leaves %d)",
+					len(snapshot.Nodes), expectedNodes, snapshot.LayerIndex, expectedLeaves)
+			}
+
+			// Verify data-region snapshot nodes are non-zero (random data produces non-zero hashes)
+			leavesPerNode := int64(1) << uint(snapshot.LayerIndex)
+			dataNodes := (int64(fx.PayloadSize)*128/127 + leavesPerNode*32 - 1) / (leavesPerNode * 32)
+			if dataNodes > int64(len(snapshot.Nodes)) {
+				dataNodes = int64(len(snapshot.Nodes))
+			}
+			for i := int64(0); i < dataNodes; i++ {
+				if snapshot.Nodes[i] == [32]byte{} {
+					t.Errorf("snapshot node %d is all-zero but covers data region", i)
+				}
+			}
+		})
+	}
+}
+
+// TestSnapshotMatchesPlainDigest verifies that the CommP from
+// DigestWithSnapshot is identical to the CommP from plain Digest for the same
+// data.
+func TestSnapshotMatchesPlainDigest(t *testing.T) {
+	t.Parallel()
+
+	for _, fx := range snapshotFixtures {
+		fx := fx
+		t.Run(fmt.Sprintf("%d", fx.PayloadSize), func(t *testing.T) {
+			t.Parallel()
+
+			if testing.Short() && fx.PayloadSize > 1<<26 {
+				t.Skip("skipping large fixture in short mode")
+			}
+
+			data := generateDeterministicData(fx.PayloadSize)
+
+			// Plain digest
+			plain := &Calc{}
+			defer plain.Reset()
+			if _, err := io.Copy(plain, bytes.NewReader(data)); err != nil {
+				t.Fatalf("plain Copy failed: %v", err)
+			}
+			plainCommP, plainSize, err := plain.Digest()
+			if err != nil {
+				t.Fatalf("plain Digest failed: %v", err)
+			}
+
+			// Snapshot digest
+			snap := NewCalcWithSnapshot(testLayerIdx)
+			defer snap.Reset()
+			if _, err := io.Copy(snap, bytes.NewReader(data)); err != nil {
+				t.Fatalf("snap Copy failed: %v", err)
+			}
+			snapCommP, snapSize, snapshot, err := snap.DigestWithSnapshot()
+			if err != nil {
+				t.Fatalf("snap DigestWithSnapshot failed: %v", err)
+			}
+
+			if !bytes.Equal(plainCommP, snapCommP) {
+				t.Errorf("CommP divergence:\n  plain %x\n  snap  %x", plainCommP, snapCommP)
+			}
+			if plainSize != snapSize {
+				t.Errorf("padded size divergence: plain %d, snap %d", plainSize, snapSize)
+			}
+
+			if snapshot == nil {
+				t.Fatal("snapshot is nil")
+			}
+			if len(snapshot.Nodes) == 0 {
+				t.Error("snapshot has zero nodes")
+			}
+		})
+	}
+}
+
+// sha254Parent hashes two 32-byte nodes into a parent using SHA-254
+// (SHA-256 with top 2 bits of byte 31 zeroed).
+func sha254Parent(left, right [32]byte) [32]byte {
+	var buf [64]byte
+	copy(buf[:32], left[:])
+	copy(buf[32:], right[:])
+	h := sha256.Sum256(buf[:])
+	h[31] &= 0x3F
+	return h
+}
+
+// rebuildSnapshotRoot hashes the snapshot nodes upward to reconstruct the
+// merkle root.
+func rebuildSnapshotRoot(snapshot *SnapshotLayer) [32]byte {
+	level := snapshot.Nodes
+	layerIdx := snapshot.LayerIndex
+
+	for len(level) > 1 {
+		nextLen := (len(level) + 1) / 2
+		next := make([][32]byte, nextLen)
+		for i := 0; i < len(level); i += 2 {
+			left := level[i]
+			var right [32]byte
+			if i+1 < len(level) {
+				right = level[i+1]
+			} else {
+				copy(right[:], stackedNulPadding[layerIdx])
+			}
+			next[i/2] = sha254Parent(left, right)
+		}
+		level = next
+		layerIdx++
+	}
+
+	return level[0]
+}
+
+// TestSnapshotUpperTreeRebuildsToCommP verifies that hashing the snapshot nodes
+// upward through the remaining tree levels produces the externally-anchored
+// CommP. This proves the captured nodes are the correct intermediate hashes,
+// not just plausible metadata. If any node were wrong, the rebuilt root would
+// diverge from the known-good CommP.
+func TestSnapshotUpperTreeRebuildsToCommP(t *testing.T) {
+	t.Parallel()
+
+	for _, fx := range snapshotFixtures {
+		fx := fx
+		t.Run(fmt.Sprintf("%d", fx.PayloadSize), func(t *testing.T) {
+			t.Parallel()
+
+			if testing.Short() && fx.PayloadSize > 1<<26 {
+				t.Skip("skipping large fixture in short mode")
+			}
+
+			expectedCommP := decodeFixtureCommP(fx.CommPCID)
+			data := generateDeterministicData(fx.PayloadSize)
+
+			cp := NewCalcWithSnapshot(testLayerIdx)
+			defer cp.Reset()
+
+			if _, err := io.Copy(cp, bytes.NewReader(data)); err != nil {
+				t.Fatalf("Copy failed: %v", err)
+			}
+
+			_, _, snapshot, err := cp.DigestWithSnapshot()
+			if err != nil {
+				t.Fatalf("DigestWithSnapshot failed: %v", err)
+			}
+
+			rebuilt := rebuildSnapshotRoot(snapshot)
+			if rebuilt != expectedCommP {
+				t.Errorf("rebuilt root mismatch:\n  got  %x\n  want %x", rebuilt, expectedCommP)
+			}
+		})
+	}
+}
+
+// TestSnapshotProductionMode verifies snapshot capture with production-mode
+// granularity (~4 MiB per node).
+func TestSnapshotProductionMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping production-mode snapshot test in short mode")
+	}
+	t.Parallel()
+
+	// Use the 32 MiB fixture with production layer
+	fx := snapshotFixtures[5] // 33292288 bytes
+	expectedCommP := decodeFixtureCommP(fx.CommPCID)
+	data := generateDeterministicData(fx.PayloadSize)
+
+	cp := NewCalcWithSnapshot(prodLayerIdx)
+	defer cp.Reset()
+
+	if _, err := io.Copy(cp, bytes.NewReader(data)); err != nil {
+		t.Fatalf("Copy failed: %v", err)
+	}
+
+	commP, paddedSize, snapshot, err := cp.DigestWithSnapshot()
+	if err != nil {
+		t.Fatalf("DigestWithSnapshot failed: %v", err)
+	}
+
+	if paddedSize != fx.PieceSize {
+		t.Errorf("padded size: got %d, want %d", paddedSize, fx.PieceSize)
+	}
+
+	var gotCommP [32]byte
+	copy(gotCommP[:], commP)
+	if gotCommP != expectedCommP {
+		t.Errorf("CommP mismatch:\n  got  %x\n  want %x", gotCommP, expectedCommP)
+	}
+
+	if snapshot.LayerIndex != prodLayerIdx {
+		t.Errorf("expected layer %d, got %d", prodLayerIdx, snapshot.LayerIndex)
+	}
+
+	expectedNodes := int(fx.PieceSize / 32 >> prodLayerIdx)
+	if len(snapshot.Nodes) != expectedNodes {
+		t.Errorf("node count: got %d, want %d", len(snapshot.Nodes), expectedNodes)
+	}
+}
+
+// TestSnapshotCalcReuse verifies that a Calc with snapshot can be reused after
+// DigestWithSnapshot resets internal state.
+func TestSnapshotCalcReuse(t *testing.T) {
+	t.Parallel()
+
+	fx := snapshotFixtures[3]
+
+	cp := NewCalcWithSnapshot(testLayerIdx)
+	defer cp.Reset()
+
+	firstData := generateDeterministicData(fx.PayloadSize)
+	if _, err := io.Copy(cp, bytes.NewReader(firstData)); err != nil {
+		t.Fatalf("first copy failed: %v", err)
+	}
+
+	firstCommP, firstSize, firstSnapshot, err := cp.DigestWithSnapshot()
+	if err != nil {
+		t.Fatalf("first DigestWithSnapshot failed: %v", err)
+	}
+	if firstSize != fx.PieceSize {
+		t.Fatalf("first padded size: got %d, want %d", firstSize, fx.PieceSize)
+	}
+	if len(firstSnapshot.Nodes) == 0 {
+		t.Fatal("first snapshot has zero nodes")
+	}
+
+	secondData := generateDeterministicData(fx.PayloadSize)
+	secondData[0] ^= 0xff
+	if _, err := io.Copy(cp, bytes.NewReader(secondData)); err != nil {
+		t.Fatalf("second copy failed: %v", err)
+	}
+
+	secondCommP, secondSize, secondSnapshot, err := cp.DigestWithSnapshot()
+	if err != nil {
+		t.Fatalf("second DigestWithSnapshot failed: %v", err)
+	}
+	if secondSize != fx.PieceSize {
+		t.Fatalf("second padded size: got %d, want %d", secondSize, fx.PieceSize)
+	}
+
+	// Cross-check second run against plain Digest
+	plain := &Calc{}
+	defer plain.Reset()
+	if _, err := io.Copy(plain, bytes.NewReader(secondData)); err != nil {
+		t.Fatalf("plain second copy failed: %v", err)
+	}
+	expectedSecond, expectedSecondSize, err := plain.Digest()
+	if err != nil {
+		t.Fatalf("plain second Digest failed: %v", err)
+	}
+	if expectedSecondSize != secondSize {
+		t.Fatalf("plain second padded size: got %d, want %d", expectedSecondSize, secondSize)
+	}
+
+	if bytes.Equal(firstCommP, secondCommP) {
+		t.Fatal("expected reused calculator to produce a different CommP for different input")
+	}
+	if !bytes.Equal(expectedSecond, secondCommP) {
+		t.Fatalf("second CommP mismatch against plain Digest:\n  got  %x\n  want %x", secondCommP, expectedSecond)
+	}
+
+	rebuilt := rebuildSnapshotRoot(secondSnapshot)
+	var expectedSecondArr [32]byte
+	copy(expectedSecondArr[:], expectedSecond)
+	if rebuilt != expectedSecondArr {
+		t.Fatalf("rebuilt snapshot root mismatch on reuse:\n  got  %x\n  want %x", rebuilt, expectedSecondArr)
+	}
+}
+
+// TestSnapshotResetClearsCollectedNodes verifies that Reset() clears collected
+// snapshot nodes.
+func TestSnapshotResetClearsCollectedNodes(t *testing.T) {
+	t.Parallel()
+
+	fx := snapshotFixtures[2]
+	cp := NewCalcWithSnapshot(testLayerIdx)
+
+	data := generateDeterministicData(fx.PayloadSize)
+	if _, err := io.Copy(cp, bytes.NewReader(data)); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+
+	cp.Reset()
+
+	if len(cp.snapshot.nodes) != 0 {
+		t.Fatalf("snapshot nodes not cleared on Reset: got %d", len(cp.snapshot.nodes))
+	}
+}
+
+// TestSnapshotLayerOOB verifies that DigestWithSnapshot returns CommP but nil
+// snapshot when the requested layer index exceeds the tree height.
+func TestSnapshotLayerOOB(t *testing.T) {
+	t.Parallel()
+
+	// 8128 bytes -> 8192 padded -> 256 leaves -> tree height 8
+	// Layer 20 is out of bounds
+	expectedCommP := decodeFixtureCommP(snapshotFixtures[0].CommPCID)
+	data := generateDeterministicData(8128)
+
+	cp := NewCalcWithSnapshot(20)
+	defer cp.Reset()
+
+	if _, err := io.Copy(cp, bytes.NewReader(data)); err != nil {
+		t.Fatalf("Copy failed: %v", err)
+	}
+
+	commP, paddedSize, snapshot, err := cp.DigestWithSnapshot()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if paddedSize != 8192 {
+		t.Errorf("padded size: got %d, want 8192", paddedSize)
+	}
+	var gotCommP [32]byte
+	copy(gotCommP[:], commP)
+	if gotCommP != expectedCommP {
+		t.Errorf("CommP mismatch:\n  got  %x\n  want %x", gotCommP, expectedCommP)
+	}
+	if snapshot != nil {
+		t.Errorf("expected nil snapshot for OOB layer, got %+v", snapshot)
+	}
+}
+
+// TestDigestWithSnapshotOnPlainCalc verifies that calling DigestWithSnapshot on
+// a Calc not created with NewCalcWithSnapshot returns an error.
+func TestDigestWithSnapshotOnPlainCalc(t *testing.T) {
+	t.Parallel()
+
+	cp := &Calc{}
+	defer cp.Reset()
+
+	data := generateDeterministicData(8128)
+	if _, err := io.Copy(cp, bytes.NewReader(data)); err != nil {
+		t.Fatalf("Copy failed: %v", err)
+	}
+
+	_, _, _, err := cp.DigestWithSnapshot()
+	if err == nil {
+		t.Fatal("expected error calling DigestWithSnapshot on plain Calc, got nil")
+	}
+}
+
+func TestSnapshotLayerIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		targetPadded uint64
+		expectLayer  int
+		description  string
+	}{
+		{32, 1, "single leaf, clamped to minimum"},
+		{64, 1, "2 leaves, layer 1"},
+		{128, 2, "4 leaves, layer 2"},
+		{2048, 6, "64 leaves, ~2 KiB padded"},
+		{4 << 20, 17, "~4 MiB padded"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			got := SnapshotLayerIndex(tc.targetPadded)
+			if got != tc.expectLayer {
+				t.Errorf("SnapshotLayerIndex(%d): got %d, want %d", tc.targetPadded, got, tc.expectLayer)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This also raises the maximum theoretical size it can work on from 64GiB padded to 32 PiB padded; increasing `MaxLayers` is a very minor extra compute cost on `init()` to generate `stackedNulPadding` and a tiny bit more memory to store that plus we expand the fixed `layerQueues` array to this new number (from 33 to 52 elements).

New feature has a new API and is essentially a noop for existing usage.

The minio/sha256-simd version bump is just inheriting [one](https://github.com/minio/sha256-simd/commit/6096f891a77bfe490cbea7a424c821b5fdb92849) minor commit for a feature we don't currently use, but it was tagged after that.